### PR TITLE
Add documentation and example for k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ The Scope IOWait plugin is a GO application that uses [`iostat`](https://linux.d
 
 ## How to Run Scope IOWait Plugin
 
+The Scope IOWait plugin can be executed stand alone.
+It will respond to `GET /report` request on the `/var/run/scope/plugins/iowait/iowait.sock` in a JSON format.
+If the running plugin has been registered by Scope, you will see it in the list of `PLUGINS` in the bottom right of the UI (see the red rectangle in the above figure).
+The measured value is shown in the *STATUS* section (see the circle in the above figure).
+
 ### Using a pre-built Docker image
 
 If you want to make sure of running the latest available version of the plugin, you pull the image from docker hub.
@@ -37,9 +42,6 @@ kubectl apply -f https://github.com/weaveworks-plugins/scope-iowait/tree/master/
 git clone git@github.com:weaveworks-plugins/scope-iowait.git
 cd scope-iowait; make;
 ```
-
-**Note** If Scope IOWait plugin has been registered by Scope, you will see it in the list of `PLUGINS` in the bottom right of the UI (see the rectangle in the above figure).
-The measured value is showed in the *STATUS* section (see the circle in the above figure).
 
 ## How to use Scope IOWait Plugin
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Scope IOWait plugin is a GO application that uses [`iostat`](https://linux.d
 
 ## How to Run Scope IOWait Plugin
 
-* Using a pre-built Docker image
+### Using a pre-built Docker image
 
 If you want to make sure of running the latest available version of the plugin, you pull the image from docker hub.
 
@@ -23,7 +23,15 @@ docker run --rm -ti \
 	--name weaveworksplugins-scope-iowait weaveworksplugins/scope-iowait:latest
 ```
 
-* Recompiling an image
+### Kubernetes
+
+If you want to use the Scope IOWait plugin in an already set up Kubernetes cluster with Weave Scope running on it, you just need to run:
+
+```
+kubectl apply -f https://github.com/weaveworks-plugins/scope-iowait/tree/master/deployments/k8s-iowait.yaml
+```
+
+### Recompiling an image
 
 ```
 git clone git@github.com:weaveworks-plugins/scope-iowait.git

--- a/deployments/k8s-iowait.yaml
+++ b/deployments/k8s-iowait.yaml
@@ -20,14 +20,9 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
-          - name: docker-sock
-            mountPath: /var/run/docker.sock
           - name: scope-plugins
             mountPath: /var/run/scope/plugins
       volumes:
-      - name: docker-sock
-        hostPath:
-          path: /var/run/docker.sock
       - name: scope-plugins
         hostPath:
           path: /var/run/scope/plugins

--- a/deployments/k8s-iowait.yaml
+++ b/deployments/k8s-iowait.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: weavescope
+    weavescope-component: weavescope-iowait-plugin
+  name: weavescope-iowait-plugin
+spec:
+  template:
+    metadata:
+      labels:
+        app: weavescope
+        weavescope-component: weavescope-iowait-plugin
+    spec:
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: weavescope-iowait-plugin
+          image: weaveworksplugins/scope-iowait:latest
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-sock
+            mountPath: /var/run/docker.sock
+          - name: scope-plugins
+            mountPath: /var/run/scope/plugins
+      volumes:
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: scope-plugins
+        hostPath:
+          path: /var/run/scope/plugins

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -10,21 +9,46 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
-func main() {
-	hostname, _ := os.Hostname()
-	var (
-		addr   = flag.String("addr", "/var/run/scope/plugins/iowait.sock", "unix socket to listen for connections on")
-		hostID = flag.String("hostname", hostname, "hostname of the host running this plugin")
-	)
-	flag.Parse()
+func setupSocket(socketPath string) (net.Listener, error) {
+	os.RemoveAll(filepath.Dir(socketPath))
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create directory %q: %v", filepath.Dir(socketPath), err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %q: %v", socketPath, err)
+	}
 
-	log.Printf("Starting on %s...\n", *hostID)
+	log.Printf("Listening on: unix://%s", socketPath)
+	return listener, nil
+}
+
+func setupSignals(socketPath string) {
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+	go func() {
+		<-interrupt
+		os.RemoveAll(filepath.Dir(socketPath))
+		os.Exit(0)
+	}()
+}
+
+func main() {
+	// We put the socket in a sub-directory to have more control on the permissions
+	const socketPath = "/var/run/scope/plugins/iowait/iowait.sock"
+	hostID, _ := os.Hostname()
+
+	// Handle the exit signal
+	setupSignals(socketPath)
+
+	log.Printf("Starting on %s...\n", hostID)
 
 	// Check we can get the iowait for the system
 	_, err := iowait()
@@ -32,27 +56,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	os.Remove(*addr)
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-	go func() {
-		<-interrupt
-		os.Remove(*addr)
-		os.Exit(0)
-	}()
-
-	listener, err := net.Listen("unix", *addr)
+	listener, err := setupSocket(socketPath)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer func() {
 		listener.Close()
-		os.Remove(*addr)
+		os.RemoveAll(filepath.Dir(socketPath))
 	}()
 
-	log.Printf("Listening on: unix://%s", *addr)
-
-	plugin := &Plugin{HostID: *hostID}
+	plugin := &Plugin{HostID: hostID}
 	http.HandleFunc("/report", plugin.Report)
 	http.HandleFunc("/control", plugin.Control)
 	if err := http.Serve(listener, nil); err != nil {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -32,7 +33,7 @@ func setupSocket(socketPath string) (net.Listener, error) {
 
 func setupSignals(socketPath string) {
 	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-interrupt
 		os.RemoveAll(filepath.Dir(socketPath))


### PR DESCRIPTION
This PR adds documentation and an example of how to deploy the plugin on Kubernetes.

It also fixes an issue with the plugin socket directory adding a directory per plugin in the `/var/run/scope/plugins` directory. It ensures that the `/var/run/scope/plugins` is created in case it does not exist because there is no guarantee that scope will start before the plugin.

This PR partially addresses https://github.com/weaveworks/scope/issues/1963

/cc @2opremio @alban